### PR TITLE
feat(mise): reorganize tool management with profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Machine-specific mise config
+config/mise/config.local.toml
+config/mise/config.*.local.toml

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,6 @@
+# Load local environment variables (machine-specific, not tracked in git)
+[[ -f ~/.env.local ]] && source ~/.env.local
+
 # Paths (unique)
 export PNPM_HOME="$HOME/.local/share/pnpm"
 typeset -gU cdpath fpath mailpath path

--- a/config/mise/config.dev.toml
+++ b/config/mise/config.dev.toml
@@ -1,0 +1,15 @@
+# Development tools (loaded when MISE_ENV includes "dev")
+[tools]
+devcontainer-cli = "latest"
+fd = "latest"
+fzf = "latest"
+gcloud = "latest"
+ghq = "latest"
+herdr = "latest"
+kubectl = "latest"
+lazygit = "latest"
+neovim = "latest"
+python = "3.12"
+ripgrep = "latest"
+tree-sitter = "latest"
+"github:astral-sh/uv" = "latest"

--- a/config/mise/config.local.toml.example
+++ b/config/mise/config.local.toml.example
@@ -1,0 +1,17 @@
+# Optional tools (machine-specific, not tracked in git)
+# Copy this file to config.local.toml and customize as needed
+[tools]
+go-jira = "latest"
+"npm:@openai/codex" = "0.142.5"
+"npm:hunkdiff" = "latest"
+ollama = "latest"
+powershell = "latest"
+
+[tools."http:agy"]
+version = "1.0.15"
+rename_exe = "agy"
+
+[tools."http:agy".platforms]
+linux-x64 = { url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.15-5090589570629632/linux-x64/cli_linux_x64.tar.gz" }
+macos-arm64 = { url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.15-5090589570629632/darwin-arm/cli_mac_arm64.tar.gz" }
+macos-x64 = { url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.15-5090589570629632/darwin-x64/cli_mac_x64.tar.gz" }

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,5 +1,10 @@
+# Essential tools (always loaded)
 [tools]
-"github:rossmacarthur/sheldon" = "latest"
+gh = "latest"
 node = "lts"
 pnpm = "latest"
+"github:rossmacarthur/sheldon" = "latest"
 starship = "latest"
+
+[settings]
+fetch_remote_versions_cache = "7d"

--- a/config/mise/miserc.toml
+++ b/config/mise/miserc.toml
@@ -1,0 +1,3 @@
+# mise environment configuration
+# This file sets which config environments to load
+env = ["dev"]


### PR DESCRIPTION
## Summary
Reorganize mise tool configuration with profile-based separation.

## Changes

### Tool Configuration Split
- `config.toml`: Essential tools (gh, node, pnpm, sheldon, starship)
- `config.dev.toml`: Development tools (neovim, python, fzf, ripgrep, etc.)
- `config.local.toml.example`: Template for optional/machine-specific tools
- `miserc.toml`: Default environment set to `dev`

### Environment Variable Support
- Add `~/.env.local` loading in `.zshrc` for machine-specific config
- Supports `MISE_ENV` customization (e.g., `MISE_ENV="dev,local"`)

### Git Configuration
- Add `.gitignore` to exclude `config.local.toml` from version control

Closes #32