### PR TITLE
feat(starship): support local config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-# Machine-specific mise config
+# Machine-specific config (not tracked)
 config/mise/config.local.toml
 config/mise/config.*.local.toml
+config/starship.local.toml

--- a/.zshrc
+++ b/.zshrc
@@ -43,7 +43,8 @@ zstyle ':completion:*:*:*:*:descriptions' format '%F{green}-- %d --%f'
 zstyle ':completion:*:messages' format ' %F{purple} -- %d --%f'
 zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
 
-# starship
+# starship (use local config if available)
+[[ -f ~/.config/starship.local.toml ]] && export STARSHIP_CONFIG=~/.config/starship.local.toml
 eval "$(starship init zsh)"
 
 # zsh settings


### PR DESCRIPTION
## Summary
Add support for machine-specific starship configuration.

## Changes
- Check for `~/.config/starship.local.toml` and use it if present
- Add `config/starship.local.toml` to `.gitignore`

## Usage
1. Create `~/.dotfiles/config/starship.local.toml` with custom modules
2. Symlink to `~/.config/starship.local.toml`
3. Shell will automatically use local config on next startup

Closes #39