### PR TITLE
feat: add local.d/ support and profiles/ templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Machine-specific config (not tracked)
+local.d/
 config/mise/config.local.toml
 config/mise/config.*.local.toml
 config/starship.local.toml

--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,5 @@
-# Load local environment variables (machine-specific, not tracked in git)
-[[ -f ~/.env.local ]] && source ~/.env.local
+# Load local configs (machine-specific, not tracked in git)
+for f in ~/.dotfiles/local.d/*.sh(N); do source $f; done
 
 # Paths (unique)
 export PNPM_HOME="$HOME/.local/share/pnpm"

--- a/profiles/wsl/env.sh
+++ b/profiles/wsl/env.sh
@@ -1,0 +1,4 @@
+# WSL-specific environment variables
+
+# WSL home directory
+export WINHOME=$(wslpath "$(powershell.exe -c 'echo $env:USERPROFILE')")


### PR DESCRIPTION
## Summary
Add `local.d/` directory pattern for loading machine-specific configurations in zshrc.
Also introduce `profiles/` directory for environment templates (wsl, macos, linux, container, etc.).

## Changes
- `.zshrc`: Load `local.d/*.sh` files for machine-specific configs
- `.gitignore`: Add `local.d/` to ignored paths (machine-specific configs are not tracked)
- `profiles/wsl/env.sh`: Add WSL environment template

## Usage
```bash
# Create local.d/ directory
mkdir -p ~/.dotfiles/local.d

# Set environment variables and tokens
echo 'export MISE_ENV="dev,local"' > ~/.dotfiles/local.d/00-env.sh
echo 'export GITHUB_TOKEN="..."' > ~/.dotfiles/local.d/10-tokens.sh

# For WSL environment, symlink from profiles
ln -s ../profiles/wsl/env.sh ~/.dotfiles/local.d/30-wsl-env.sh
```

## Design
- `local.d/`: Machine-specific configs (gitignored, not tracked)
- `profiles/`: Environment templates (git tracked, reusable across machines)
- Users symlink from `profiles/` to `local.d/` to activate environment-specific settings

Closes #42