### PR TITLE
feat: add -s option support to install.sh with wsl preset

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,3 @@
-# Load local configs (machine-specific, not tracked in git)
-for f in ~/.dotfiles/local.d/*.sh(N); do source $f; done
-
 # Paths (unique)
 export PNPM_HOME="$HOME/.local/share/pnpm"
 typeset -gU cdpath fpath mailpath path
@@ -83,3 +80,7 @@ HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 setopt hist_ignore_all_dups
+
+# Load local configs (machine-specific, not tracked in git)
+for f in ~/.dotfiles/local.d/*.sh(N); do source $f; done
+

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,21 @@ has() {
   return $?
 }
 
+# Parse options
+PRESET=""
+while getopts "s:" opt; do
+  case $opt in
+    s)
+      PRESET="$OPTARG"
+      ;;
+    \?)
+      echo "Usage: $0 [-s preset]"
+      echo "  Presets: wsl, container (default)"
+      exit 1
+      ;;
+  esac
+done
+
 DOTPATH=~/.dotfiles
 
 # Clone if not exists
@@ -58,5 +73,32 @@ fi
 
 # Set git commit template
 git config --global commit.template "${DOTPATH}/config/git/commit_template"
+
+# Apply preset-specific configurations
+case "$PRESET" in
+  wsl)
+    echo "Applying WSL preset..."
+    # Create local.d directory
+    mkdir -p "${DOTPATH}/local.d"
+    # Write MISE_ENV setting
+    echo 'export MISE_ENV="dev,local"' > "${DOTPATH}/local.d/00-env.sh"
+    # Symlink WSL-specific env
+    ln -snfv "${DOTPATH}/profiles/wsl/env.sh" "${DOTPATH}/local.d/30-wsl-env.sh"
+    # Set MISE_ENV for current session and install dev tools
+    if has "mise"; then
+      echo "Installing dev tools via mise..."
+      export MISE_ENV="dev,local"
+      mise install
+    fi
+    ;;
+  container|"")
+    # Default/container preset: no additional setup needed
+    ;;
+  *)
+    echo "Unknown preset: $PRESET"
+    echo "Available presets: wsl, container"
+    exit 1
+    ;;
+esac
 
 echo "Installation complete. Please restart your shell."


### PR DESCRIPTION
## Summary
Add `-s` option parsing to install.sh and implement the `wsl` preset for WSL environments.

## Changes
- Add `-s` option parsing to install.sh
- Implement `-s wsl` preset:
  - Create `local.d/` directory
  - Write `MISE_ENV="dev,local"` to `local.d/00-env.sh`
  - Symlink `profiles/wsl/env.sh` to `local.d/30-wsl-env.sh`
  - Install dev tools via mise
- Move `local.d/` loading to end of `.zshrc` (after mise is available in container)
- Default (no option or `-s container`) keeps current behavior

## Usage
```bash
# WSL environment (with dev tools)
./install.sh -s wsl

# Normal install (no preset, same as container)
./install.sh
./install.sh -s container
```

Closes #44