### PR TITLE
fix: remove hardcoded env from miserc.toml

### DIFF
--- a/config/mise/miserc.toml
+++ b/config/mise/miserc.toml
@@ -1,3 +1,4 @@
 # mise environment configuration
-# This file sets which config environments to load
-env = ["dev"]
+# Environment is controlled via MISE_ENV variable (set in local.d/00-env.sh)
+# - Default (container): no extra environments
+# - WSL: MISE_ENV="dev,local" loads config.dev.toml and config.local.toml


### PR DESCRIPTION
## Problem
Container preset incorrectly installs dev tools from `config.dev.toml`.

## Cause
`miserc.toml` had `env = ["dev"]` hardcoded, which always loads `config.dev.toml` regardless of the preset.

## Solution
Remove `env = ["dev"]` from `miserc.toml`. Environment is now controlled via `MISE_ENV` variable set in `local.d/00-env.sh` (for wsl preset).

Fixes #46