### PR TITLE
feat(nvim): enable line wrap by default

### DIFF
--- a/config/nvim/lua/config/options.lua
+++ b/config/nvim/lua/config/options.lua
@@ -2,6 +2,8 @@
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- Add any additional options here
 
+vim.opt.wrap = true
+
 vim.g.clipboard = {
   name = "win32yank-wsl",
   copy = {


### PR DESCRIPTION
## Changes
Enable line wrap by default in LazyVim configuration.

LazyVim defaults to `wrap = false`, but wrapped lines improve readability.

Closes #60