### PR TITLE
refactor: use mise install instead of explicit tool list

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ fi
 # Install tools via mise
 if has "mise"; then
   echo "Installing tools via mise..."
-  mise use -g starship github:rossmacarthur/sheldon node@lts pnpm@latest
+  mise install
 else
   echo "mise not found even after installation attempt."
   exit 1


### PR DESCRIPTION
## Overview
Replace `mise use -g starship github:rossmacarthur/sheldon node@lts pnpm@latest` with `mise install` in install.sh.

## Changes
- Use `mise install` which reads from `config/mise/config.toml`

## Purpose
- Centralize tool management in mise config files
- Improve maintainability by eliminating duplicate tool definitions
- Adding/removing tools only requires editing the mise config, not install.sh

Closes #62