### PR TITLE
feat(mise): add minimum_release_age for safer updates

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -7,4 +7,4 @@ pnpm = "latest"
 starship = "latest"
 
 [settings]
-fetch_remote_versions_cache = "7d"
+minimum_release_age = "7d"


### PR DESCRIPTION
## Overview
Add `minimum_release_age` setting to wait 7 days after release before updating tools.

## Changes
- Replace `fetch_remote_versions_cache` with `minimum_release_age = "7d"`

## Purpose
- **Stability**: Avoid installing freshly released versions that may have bugs
- **Safety**: Give time for community to discover issues in new releases

Closes #63