### PR TITLE
feat(nvim): add winbar with breadcrumb-style path display

### DIFF
--- a/config/nvim/lua/plugins/winbar.lua
+++ b/config/nvim/lua/plugins/winbar.lua
@@ -1,0 +1,14 @@
+-- Winbar configuration: Display path in breadcrumb format
+return {
+  {
+    "LazyVim/LazyVim",
+    opts = function(_, opts)
+      -- Set highlight groups
+      vim.api.nvim_set_hl(0, "WinBarPath", { fg = "#808080", bg = "NONE" })
+      vim.api.nvim_set_hl(0, "WinBarFile", { fg = "#DCDCAA", bg = "NONE", bold = true })
+
+      -- Enable winbar
+      vim.opt.winbar = "%{%v:lua.require'util.winbar'.get_winbar()%}"
+    end,
+  },
+}

--- a/config/nvim/lua/util/winbar.lua
+++ b/config/nvim/lua/util/winbar.lua
@@ -1,0 +1,61 @@
+-- Winbar: Display path from repository root in breadcrumb format
+local M = {}
+
+--- Get git repository root
+---@return string|nil
+local function get_git_root()
+  local git_root = vim.fn.systemlist("git rev-parse --show-toplevel 2>/dev/null")[1]
+  if vim.v.shell_error ~= 0 or not git_root then
+    return nil
+  end
+  return git_root
+end
+
+--- Convert file path to breadcrumb format
+---@return string
+function M.get_winbar()
+  local bufname = vim.api.nvim_buf_get_name(0)
+
+  -- Skip empty or special buffers
+  if bufname == "" then
+    return ""
+  end
+
+  local buftype = vim.bo.buftype
+  if buftype ~= "" then
+    return ""
+  end
+
+  -- Convert to absolute path
+  local filepath = vim.fn.fnamemodify(bufname, ":p")
+
+  -- Get relative path from git root
+  local git_root = get_git_root()
+  local display_path
+
+  if git_root then
+    -- Relative path from git root
+    if filepath:sub(1, #git_root) == git_root then
+      display_path = filepath:sub(#git_root + 2) -- +2 for trailing slash
+    else
+      display_path = vim.fn.fnamemodify(bufname, ":~:.")
+    end
+  else
+    -- Relative path from CWD if not in a git repository
+    display_path = vim.fn.fnamemodify(bufname, ":~:.")
+  end
+
+  -- Convert path to breadcrumb format (/ to ›)
+  local parts = vim.split(display_path, "/", { plain = true })
+
+  -- Highlight filename part
+  if #parts > 1 then
+    local dirs = table.concat(vim.list_slice(parts, 1, #parts - 1), " › ")
+    local filename = parts[#parts]
+    return "%#WinBarPath#" .. dirs .. " › %#WinBarFile#" .. filename .. "%*"
+  else
+    return "%#WinBarFile#" .. parts[1] .. "%*"
+  end
+end
+
+return M


### PR DESCRIPTION
## Overview
Add winbar to nvim configuration that displays the current file path in breadcrumb format from the git repository root.

## Changes
- Add `lua/util/winbar.lua` for path formatting logic
- Add `lua/plugins/winbar.lua` for LazyVim integration
- Display file path from git root with `›` separator
- Highlight filename with distinct color (yellow, bold)

## Purpose
- Easier to identify which file is open in each window when using split windows
- Show file location relative to git root for better context

Closes #66