### PR TITLE
feat(zsh): add INC_APPEND_HISTORY and SHARE_HISTORY options

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -80,6 +80,8 @@ HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 setopt hist_ignore_all_dups
+setopt inc_append_history  # Append each command to history immediately
+setopt share_history        # Share history across multiple terminal sessions
 
 # Load local configs (machine-specific, not tracked in git)
 for f in ~/.dotfiles/local.d/*.sh(N); do source $f; done


### PR DESCRIPTION
## Overview
Add `inc_append_history` and `share_history` to zsh history settings.

## Changes
- `.zshrc`: Add two setopt lines to the history settings section
  - `setopt inc_append_history` — append each command to history immediately after execution
  - `setopt share_history` — share history across multiple terminal sessions in real time

Closes #72